### PR TITLE
feat: Add TanStack Query, update `article` page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,8 @@
         "@radix-ui/react-separator": "^1.1.2",
         "@radix-ui/react-slot": "^1.1.2",
         "@radix-ui/react-tabs": "^1.1.4",
+        "@tanstack/react-query": "^5.80.7",
+        "@tanstack/react-query-devtools": "^5.80.7",
         "@types/nodemailer": "^6.4.17",
         "axios": "^1.8.4",
         "better-auth": "^1.2.4",
@@ -4942,6 +4944,59 @@
         "lightningcss": "^1.29.1",
         "postcss": "^8.4.41",
         "tailwindcss": "4.0.12"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.80.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.80.7.tgz",
+      "integrity": "sha512-s09l5zeUKC8q7DCCCIkVSns8zZrK4ZDT6ryEjxNBFi68G4z2EBobBS7rdOY3r6W1WbUDpc1fe5oY+YO/+2UVUg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.80.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.80.0.tgz",
+      "integrity": "sha512-D6gH4asyjaoXrCOt5vG5Og/YSj0D/TxwNQgtLJIgWbhbWCC/emu2E92EFoVHh4ppVWg1qT2gKHvKyQBEFZhCuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.80.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.80.7.tgz",
+      "integrity": "sha512-u2F0VK6+anItoEvB3+rfvTO9GEh2vb00Je05OwlUe/A0lkJBgW1HckiY3f9YZa+jx6IOe4dHPh10dyp9aY3iRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.80.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.80.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.80.7.tgz",
+      "integrity": "sha512-7Dz/19fVo0i+jgLVBabV5vfGOlLyN5L1w8w1/ogFhe6ItNNsNA+ZgNTbtiKpbR3CcX2WDRRTInz1uMSmHzTsoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.80.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.80.7",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@types/estree": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "@radix-ui/react-separator": "^1.1.2",
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-tabs": "^1.1.4",
+    "@tanstack/react-query": "^5.80.7",
+    "@tanstack/react-query-devtools": "^5.80.7",
     "@types/nodemailer": "^6.4.17",
     "axios": "^1.8.4",
     "better-auth": "^1.2.4",

--- a/src/app/[username]/[articleslug]/page.tsx
+++ b/src/app/[username]/[articleslug]/page.tsx
@@ -3,7 +3,7 @@ import { Badge } from "@/components/ui/badge";
 import { Heart, MessageSquare } from "lucide-react";
 import Image from "next/image";
 import { api } from "@/utils/api";
-import { useState, useEffect, useContext, useRef } from "react";
+import { useContext, useRef } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { Avatar, AvatarImage, AvatarFallback } from "@radix-ui/react-avatar";
 import { ArticleWithAuthor } from "@/lib/types";
@@ -13,81 +13,90 @@ import { toast } from "sonner";
 import { UserContext } from "@/contexts/UserContext";
 import { CommentsSection } from "@/components/CommentsSection";
 import { Button } from "@/components/ui/button";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ArticleLikes } from "@prisma/client";
 
 function ArticlePage() {
   const NEXT_PUBLIC_AWS_URL = process.env.NEXT_PUBLIC_AWS_URL;
   const { articleslug } = useParams<{ articleslug: string }>();
-  const [article, setArticle] = useState<ArticleWithAuthor>();
   const commentSectionRef = useRef<{ focusInput: () => void }>(null);
   const user = useContext(UserContext)?.user;
   const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["articles", articleslug],
+    queryFn: async (): Promise<ArticleWithAuthor> => {
+      const response = await api.get(`/articles?article=${articleslug}`);
+      return response.data;
+    },
+    staleTime: 5 * 60 * 1000,
+  });
 
   const addLike = async () => {
     if (!user) {
       router.push("/sign-up");
       return;
     }
-    try {
+    likeMutation.mutate();
+  };
+
+  const likeMutation = useMutation({
+    mutationFn: async () => {
       await api.post("/article-likes", {
-        articleId: article?.id,
+        articleId: data?.id,
       });
-      toast.success("Article liked");
-    } catch (error) {
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["articles", articleslug] });
+    },
+    onError: (error) => {
       console.error("Error liking article", error);
       toast.error("Something went wrong. Please try again.");
-    }
-  };
+    },
+  });
 
-  const removeLike = async () => {
-    try {
-      await api.delete(`/article-likes/${article?.id}`);
-    } catch (error) {
+  const unlikeMutation = useMutation({
+    mutationFn: async () => {
+      await api.delete(`/article-likes/${data?.id}`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["articles", articleslug] });
+    },
+    onError: (error) => {
       console.error("Error liking article", error);
-    }
-  };
+      toast.error("Something went wrong. Please try again.");
+    },
+  });
 
-  useEffect(() => {
-    if (articleslug) {
-      const getArticle = async () => {
-        try {
-          const response = await api.get(`/articles?article=${articleslug}`);
-          setArticle(response.data);
-        } catch (error) {
-          console.error(error);
-        }
-      };
-      getArticle();
-    }
-  }, [articleslug]);
-
-  if (!article) {
+  if (isLoading || !data) {
     return <Loading></Loading>;
   }
   return (
     <main className="mx-auto max-w-3xl py-20">
       <h1 className="text-4xl font-bold text-custom-text-primary">
-        {article.title}
+        {data.title}
       </h1>
       <section className="flex items-center gap-3 py-8 text-sm text-custom-text-light">
         <Avatar className="flex h-8 w-8 items-center justify-center overflow-hidden rounded-full border-[0.01rem] border-neutral-800 bg-zinc-200 text-sm hover:opacity-80 dark:border-white">
-          <Link href={`/@${article.authorSlug}`} className="flex size-full">
+          <Link href={`/@${data.authorSlug}`} className="flex size-full">
             <AvatarImage
-              src={NEXT_PUBLIC_AWS_URL + article.author.avatar!}
+              src={NEXT_PUBLIC_AWS_URL + data.author.avatar!}
               alt={"Author avatar"}
             />
             <AvatarFallback className="flex w-full items-center justify-center">
-              {article.author.name.slice(0, 2).toUpperCase()}
+              {data.author.name.slice(0, 2).toUpperCase()}
             </AvatarFallback>
           </Link>
         </Avatar>
         <Link
-          href={`/@${article.authorSlug}`}
+          href={`/@${data.authorSlug}`}
           className="font-medium text-custom-text-primary hover:underline"
         >
-          {article.author?.name}
+          {data.author?.name}
         </Link>
         <span className="flex items-center gap-1">
-          {new Date(article.createdAt).toLocaleDateString("en-IN", {
+          {new Date(data.createdAt).toLocaleDateString("en-IN", {
             year: "numeric",
             month: "long",
             day: "numeric",
@@ -96,18 +105,20 @@ function ArticlePage() {
       </section>
       <section className="mb-8 flex flex-wrap gap-3 text-sm text-custom-text-light sm:gap-4">
         <span className="flex items-center gap-1">
-          {article.readTime} min read
+          {data.readTime} min read
         </span>
         <span className="flex items-center gap-1">
-          {article.articleLikes.find((like) => like.userSlug === user?.slug) ? (
+          {data.articleLikes.find(
+            (like: ArticleLikes) => like.userSlug === user?.slug,
+          ) ? (
             <button
-              onClick={removeLike}
+              onClick={() => unlikeMutation.mutate()}
               className="flex cursor-pointer items-center gap-1"
             >
               <Heart
                 className={`h-4 w-4 fill-red-500 text-red-500 hover:fill-red-400 hover:text-red-400`}
               />
-              {article.likes}
+              {data.likes}
             </button>
           ) : (
             <button
@@ -115,33 +126,33 @@ function ArticlePage() {
               className="flex cursor-pointer items-center gap-1"
             >
               <Heart className={`h-4 w-4 hover:text-red-500`} />
-              {article.likes}
+              {data.likes}
             </button>
           )}
         </span>
         <span className="flex items-center gap-1">
           <MessageSquare className="h-4 w-4" />
-          {article.commentsCount}
+          {data.commentsCount}
         </span>
       </section>
       <div className="mb-8 w-full max-w-3xl border-b-[0.01rem] border-neutral-400"></div>
-      {article.image && (
+      {data.image && (
         <Image
-          src={NEXT_PUBLIC_AWS_URL + article.image}
+          src={NEXT_PUBLIC_AWS_URL + data.image}
           width={500}
           height={300}
-          alt={article.title}
+          alt={data.title}
           className="mt-6 rounded-lg"
         />
       )}
       <article className="wrap mt-6 space-y-4 text-lg text-custom-text-light">
         <div
           className="rich-content"
-          dangerouslySetInnerHTML={{ __html: article.content }}
+          dangerouslySetInnerHTML={{ __html: data.content }}
         />
       </article>
       <section className="mt-12 flex flex-wrap gap-2">
-        {article.tags.map((tag) => (
+        {data.tags.map((tag) => (
           <Badge
             key={tag}
             variant="secondary"
@@ -153,14 +164,16 @@ function ArticlePage() {
       </section>
       <div className="my-16 w-full max-w-3xl border-b-[0.01rem] border-neutral-400"></div>
       <div className="flex flex-wrap items-center gap-4 text-sm text-custom-text-light">
-        {article.articleLikes.find((like) => like.userSlug === user?.slug) ? (
+        {data.articleLikes.find(
+          (like: ArticleLikes) => like.userSlug === user?.slug,
+        ) ? (
           <Button
-            onClick={removeLike}
+            onClick={() => unlikeMutation.mutate()}
             variant="outline"
             className="flex items-center gap-2 border-neutral-400"
           >
             <Heart className="mr-2 h-4 w-4 fill-red-500 text-red-500 hover:fill-red-400 hover:text-red-400" />
-            Like ({article.likes})
+            Like ({data.likes})
           </Button>
         ) : (
           <Button
@@ -169,21 +182,20 @@ function ArticlePage() {
             className="group flex items-center gap-2 border-neutral-400"
           >
             <Heart className="mr-2 h-4 w-4 group-hover:text-red-500" />
-            Like ({article.likes})
+            Like ({data.likes})
           </Button>
         )}
-
         <Button
           onClick={() => commentSectionRef.current?.focusInput()}
           variant="outline"
           className="flex items-center gap-2 border-neutral-400"
         >
           <MessageSquare className="mr-2 h-4 w-4" />
-          Comment ({article.commentsCount})
+          Comment ({data.commentsCount})
         </Button>
       </div>
       <CommentsSection
-        articleId={article?.id}
+        articleId={data.id}
         ref={commentSectionRef}
       ></CommentsSection>
     </main>

--- a/src/app/[username]/following.tsx
+++ b/src/app/[username]/following.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { FollowerWithUser, FollowingWithUser } from "@/lib/types";
+import { FollowingWithUser } from "@/lib/types";
 
 export default function Following({
   following,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,9 @@
 import "./globals.css";
 import type { Metadata } from "next";
-import { ThemeProvider } from "@/contexts/ThemeContext";
 import Footer from "@/components/Footer";
-import { UserProvider } from "@/contexts/UserContext";
 import { Toaster } from "sonner";
+
+import { Providers } from "@/utils/providers";
 import Navbar from "@/components/Navbar";
 
 export const metadata: Metadata = {
@@ -29,17 +29,15 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="analaised">
-        <ThemeProvider>
-          <UserProvider>
-            <section className="flex min-h-screen flex-col bg-custom-background-home">
-              <Navbar></Navbar>
-              <span className="h-16 bg-custom-background"></span>
-              {children}
-              <Toaster position="top-center" richColors={true} />
-              <Footer></Footer>
-            </section>
-          </UserProvider>
-        </ThemeProvider>
+        <Providers>
+          <section className="flex min-h-screen flex-col bg-custom-background-home">
+            <Navbar></Navbar>
+            <span className="h-16 bg-custom-background"></span>
+            {children}
+            <Toaster position="top-center" richColors={true} />
+            <Footer></Footer>
+          </section>
+        </Providers>
       </body>
     </html>
   );

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -14,7 +14,7 @@ export const auth = betterAuth({
   },
 
   emailVerification: {
-    sendVerificationEmail: async ({ user, url, token }, request) => {
+    sendVerificationEmail: async ({ user, url, token }) => {
       console.log(
         `sendVerificationEmail: user : ${user.email}, url : ${url}, token : ${token}`,
       );

--- a/src/utils/providers.tsx
+++ b/src/utils/providers.tsx
@@ -1,0 +1,18 @@
+"use client";
+import { ReactNode } from "react";
+import { ThemeProvider } from "@/contexts/ThemeContext";
+import { UserProvider } from "@/contexts/UserContext";
+import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+
+export const Providers = ({ children }: { children: ReactNode }) => {
+  const queryClient = new QueryClient();
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider>
+        <UserProvider>{children}</UserProvider>
+      </ThemeProvider>
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  );
+};


### PR DESCRIPTION
- Implement TanStack Query for efficient data fetching and caching.
- Update `article` page to handle likes and comments dynamically without full reaload.
- Create `providers.tsx` to centralize and  manage all React providers.
- Reafactor main `layout` page to use the new `provders.tsx` setup.